### PR TITLE
Replace `available` usage with `type -q`

### DIFF
--- a/brew.fish
+++ b/brew.fish
@@ -1,5 +1,5 @@
 function init -a path --on-event init_brew
-  if not available brew
+  if not type -q brew
     echo "Please install 'brew' first!"; return 1
   end
 


### PR DESCRIPTION
`available` isn't super fishy, let's use `type -q` instead. it's quiet, it avoids redirection, and @derekstavis likes it better :P
