### PR TITLE
 set environment with `brew shellenv`

### DIFF
--- a/init.fish
+++ b/init.fish
@@ -1,22 +1,22 @@
-if status --is-login
+if status is-login
   # check $HOMEBREW_BIN and set $brew
   set -q HOMEBREW_BIN
     and set -l brew $HOMEBREW_BIN
     or set -l brew /usr/local/bin/brew
 
-  # initialized brew shell environment if $brew is valid
-  if type -q $brew; and $brew shellenv > /dev/null 2>&1
-    # By default, `brew shellenv` sets $fish_user_paths as a global variable instead of directly
-    # setting $PATH. This behavior should be avoided and thus is overriden here, since setting 
-    # a global $fish_user_paths will shadow the universal $fish_user_paths, which is supposed 
-    # to be set manually by the user by design.
-    eval ($brew shellenv | sed 's/fish_user_paths/PATH/g')
+  # By default, `brew shellenv` sets $fish_user_paths as a global variable instead of directly
+  # setting $PATH. This behavior should be avoided and thus is overriden here, since setting 
+  # a global $fish_user_paths will shadow the universal $fish_user_paths, which is supposed 
+  # to be set manually by users by design.
+  if type -q $brew; and set cmd ($brew shellenv | sed 's/fish_user_paths/PATH/g') ^ /dev/null
+    # initialized brew shell environment if $brew is valid
+    eval $cmd
     set -gx HOMEBREW_BIN $brew
-    set -gx PATH $PATH
+    set -gxp PATH
   else
     echo "Error! 'brew' not found at $brew."
     echo "Please make sure Homebrew is installed and \$HOMEBREW_BIN is correctly set!"
     echo "To install Homebrew, please check https://brew.sh"
     echo "Note that setting \$HOMEBREW_BIN is optional if the default Homebrew installation path is used."
-  end
+  end >& 2
 end

--- a/init.fish
+++ b/init.fish
@@ -1,24 +1,15 @@
-if type -q brew
-  set -l brew_paths /usr/local/bin /usr/bin /bin /usr/local/sbin /usr/sbin /sbin
+# check and set $HOMEBREW_BIN
+if not set -q HOMEBREW_BIN
+  set HOMEBREW_BIN /usr/local/bin/brew
+end
 
-  # Append all existing brew paths to PATH
-  set -l existing_brew_paths
-  for brew_path in $brew_paths
-    if test -d $brew_path
-      set PATH $PATH $brew_path
-      set existing_brew_paths $existing_brew_paths $brew_path
-    end
-  end
-
-  # Remove brew paths from tail to head that were not recently added
-  set -l number_of_paths_to_ignore (math (count $PATH) - (count $existing_brew_paths))
-  for i in (seq (count $PATH))[-1..1]
-    if test $i -le $number_of_paths_to_ignore
-      if contains $PATH[$i] $brew_paths
-        set -e PATH[$i]
-      end
-    end
-  end
+# export $HOMEBREW_BIN and initialized brew shell environment if $HOMEBREW_BIN is valid
+if type -q $HOMEBREW_BIN; and $HOMEBREW_BIN shellenv > /dev/null 2>&1
+  set -gx HOMEBREW_BIN $HOMEBREW_BIN
+  eval ($HOMEBREW_BIN shellenv)
 else
-  echo "Please install 'brew' first!"
+  echo "Error! 'brew' not found at $HOMEBREW_BIN.
+Please make sure Homebrew is installed and \$HOMEBREW_BIN is correctly set!
+To install Homebrew, please check https://brew.sh
+Note that setting \$HOMEBREW_BIN is optional if the default Homebrew installation path is used."
 end

--- a/init.fish
+++ b/init.fish
@@ -3,10 +3,12 @@ if not set -q HOMEBREW_BIN
   set HOMEBREW_BIN /usr/local/bin/brew
 end
 
-# export $HOMEBREW_BIN and initialized brew shell environment if $HOMEBREW_BIN is valid
+# initialized brew shell environment if $HOMEBREW_BIN is valid
 if type -q $HOMEBREW_BIN; and $HOMEBREW_BIN shellenv > /dev/null 2>&1
-  # the default behavior is overriden, since setting a global $fish_user_paths 
-  # will shadow the universal $fish_user_paths, which is not how it's designed to work
+  # By default, `brew shellenv` sets $fish_user_paths as a global variable instead of directly
+  # setting $PATH. This behavior should be avoided and thus is overriden here, since setting 
+  # a global $fish_user_paths will shadow the universal $fish_user_paths, which is supposed 
+  # to be set manually by the user by design.
   eval ($HOMEBREW_BIN shellenv | sed 's/fish_user_paths/PATH/g')
   set -gx HOMEBREW_BIN $HOMEBREW_BIN
   set -gx PATH $PATH

--- a/init.fish
+++ b/init.fish
@@ -1,20 +1,22 @@
-# check and set $HOMEBREW_BIN
-if not set -q HOMEBREW_BIN
-  set HOMEBREW_BIN /usr/local/bin/brew
-end
+if status --is-login
+  # check $HOMEBREW_BIN and set $brew
+  set -q HOMEBREW_BIN
+    and set -l brew $HOMEBREW_BIN
+    or set -l brew /usr/local/bin/brew
 
-# initialized brew shell environment if $HOMEBREW_BIN is valid
-if type -q $HOMEBREW_BIN; and $HOMEBREW_BIN shellenv > /dev/null 2>&1
-  # By default, `brew shellenv` sets $fish_user_paths as a global variable instead of directly
-  # setting $PATH. This behavior should be avoided and thus is overriden here, since setting 
-  # a global $fish_user_paths will shadow the universal $fish_user_paths, which is supposed 
-  # to be set manually by the user by design.
-  eval ($HOMEBREW_BIN shellenv | sed 's/fish_user_paths/PATH/g')
-  set -gx HOMEBREW_BIN $HOMEBREW_BIN
-  set -gx PATH $PATH
-else
-  echo "Error! 'brew' not found at $HOMEBREW_BIN.
-Please make sure Homebrew is installed and \$HOMEBREW_BIN is correctly set!
-To install Homebrew, please check https://brew.sh
-Note that setting \$HOMEBREW_BIN is optional if the default Homebrew installation path is used."
+  # initialized brew shell environment if $brew is valid
+  if type -q $brew; and $brew shellenv > /dev/null 2>&1
+    # By default, `brew shellenv` sets $fish_user_paths as a global variable instead of directly
+    # setting $PATH. This behavior should be avoided and thus is overriden here, since setting 
+    # a global $fish_user_paths will shadow the universal $fish_user_paths, which is supposed 
+    # to be set manually by the user by design.
+    eval ($brew shellenv | sed 's/fish_user_paths/PATH/g')
+    set -gx HOMEBREW_BIN $brew
+    set -gx PATH $PATH
+  else
+    echo "Error! 'brew' not found at $brew."
+    echo "Please make sure Homebrew is installed and \$HOMEBREW_BIN is correctly set!"
+    echo "To install Homebrew, please check https://brew.sh"
+    echo "Note that setting \$HOMEBREW_BIN is optional if the default Homebrew installation path is used."
+  end
 end

--- a/init.fish
+++ b/init.fish
@@ -5,8 +5,11 @@ end
 
 # export $HOMEBREW_BIN and initialized brew shell environment if $HOMEBREW_BIN is valid
 if type -q $HOMEBREW_BIN; and $HOMEBREW_BIN shellenv > /dev/null 2>&1
+  # the default behavior is overriden, since setting a global $fish_user_paths 
+  # will shadow the universal $fish_user_paths, which is not it's designed to work
+  eval ($HOMEBREW_BIN shellenv | sed 's/fish_user_paths/PATH/g')
   set -gx HOMEBREW_BIN $HOMEBREW_BIN
-  eval ($HOMEBREW_BIN shellenv)
+  set -gx PATH $PATH
 else
   echo "Error! 'brew' not found at $HOMEBREW_BIN.
 Please make sure Homebrew is installed and \$HOMEBREW_BIN is correctly set!

--- a/init.fish
+++ b/init.fish
@@ -5,8 +5,11 @@ end
 
 # export $HOMEBREW_BIN and initialized brew shell environment if $HOMEBREW_BIN is valid
 if type -q $HOMEBREW_BIN; and $HOMEBREW_BIN shellenv > /dev/null 2>&1
+  # the default behavior is overriden, since setting a global $fish_user_paths 
+  # will shadow the universal $fish_user_paths, which is what it's designed to be
+  eval ($HOMEBREW_BIN shellenv | sed 's/fish_user_paths/PATH/g')
   set -gx HOMEBREW_BIN $HOMEBREW_BIN
-  eval ($HOMEBREW_BIN shellenv)
+  set -gx PATH $PATH
 else
   echo "Error! 'brew' not found at $HOMEBREW_BIN.
 Please make sure Homebrew is installed and \$HOMEBREW_BIN is correctly set!


### PR DESCRIPTION
See issue #8 
`brew shellenv` already generates all the necessary codes for setting up shell environment. Using its output is the best approach.

Homebrew install its `brew` binary as /usr/local/bin/brew by default. User can provide custom installation location by setting $HOMEBREW_BIN in before.init.fish.