### PR TITLE
Add new Homebrew paths

### DIFF
--- a/conf.d/brew.fish
+++ b/conf.d/brew.fish
@@ -1,5 +1,5 @@
 if type -q brew
-  set -l brew_paths /usr/local/bin /usr/bin /bin /usr/local/sbin /usr/sbin /sbin
+  set -l brew_paths /opt/homebrew/bin /usr/local/bin /usr/bin /bin /opt/homebrew/sbin /usr/local/sbin /usr/sbin /sbin
 
   # Append all existing brew paths to PATH
   set -l existing_brew_paths


### PR DESCRIPTION
Newer installations of Homebrew use `/opt/homebrew/` instead of `/usr/local/`.

(**Update:** more specifically, the Apple M1 installs)

re #10