### PR TITLE
Add Apple Silicon support

### DIFF
--- a/conf.d/brew.fish
+++ b/conf.d/brew.fish
@@ -1,24 +1,17 @@
-if type -q brew
-  set -l brew_paths /opt/homebrew/bin /usr/local/bin /usr/bin /bin /opt/homebrew/sbin /usr/local/sbin /usr/sbin /sbin
+set -l brew_paths /opt/homebrew/bin /usr/local/bin /usr/bin /bin /opt/homebrew/sbin /usr/local/sbin /usr/sbin /sbin
 
-  # Append all existing brew paths to PATH
-  set -l existing_brew_paths
-  for brew_path in $brew_paths
-    if test -d $brew_path
-      set PATH $PATH $brew_path
-      set existing_brew_paths $existing_brew_paths $brew_path
-    end
+for brew_path in $brew_paths
+  if contains $brew_path $PATH
+    continue
   end
 
-  # Remove brew paths from tail to head that were not recently added
-  set -l number_of_paths_to_ignore (math (count $PATH) - (count $existing_brew_paths))
-  for i in (seq (count $PATH))[-1..1]
-    if test $i -le $number_of_paths_to_ignore
-      if contains $PATH[$i] $brew_paths
-        set -e PATH[$i]
-      end
-    end
+  if test -f $brew_path/brew
+    set brew_found true
+    set PATH $brew_path $PATH
+    break
   end
-else
+end
+
+if not set -q brew_found
   echo "Please install 'brew' first!"
 end

--- a/conf.d/brew.fish
+++ b/conf.d/brew.fish
@@ -6,12 +6,11 @@ for brew_path in $brew_paths
   end
 
   if test -f $brew_path/brew
-    set brew_found true
     set PATH $brew_path $PATH
     break
   end
 end
 
-if not set -q brew_found
+if not type -q brew
   echo "Please install 'brew' first!"
 end

--- a/conf.d/brew.fish
+++ b/conf.d/brew.fish
@@ -1,5 +1,5 @@
 if type -q brew
-  set -l brew_paths /usr/local/bin /usr/bin /bin /usr/local/sbin /usr/sbin /sbin
+  set -l brew_paths /opt/homebrew/bin /usr/local/bin /usr/bin /bin /opt/homebrew/sbin /usr/local/sbin /usr/sbin /sbin
 
   # Append all existing brew paths to PATH
   set -l existing_brew_paths


### PR DESCRIPTION
This is an addition to the PR #12 by @nemoDreamer.

> Newer installations of Homebrew use /opt/homebrew/ instead of /usr/local/.

The difference is the `if type -q brew` condition that didn't work for me on my M1. `type` can only find `brew` when it is already part of the `$PATH` variable, but to be part of the `$PATH` variable this fish script needs to run first.

In other words: This fish script adds necessary paths used by `brew` to `$PATH` to make `brew` accessible. Only after this script did its job, commands like `type brew` and `which brew` can finally work.